### PR TITLE
fix wrong inventory and pending knights amounts on home page

### DIFF
--- a/src/app/services/eth.service.ts
+++ b/src/app/services/eth.service.ts
@@ -396,8 +396,9 @@ export class EthService {
     for (const pool of pools) {
       const token = await (this.getPendingToken(pool.id));
       const foundToken = tokens.find(value => value.address === token.address);
+      
       if (foundToken) {
-        foundToken.balance += token.balance;
+        foundToken.pendingAmount += token.pendingAmount;
       }
       else {
         tokens.push(token);


### PR DESCRIPTION
Fix for issue https://github.com/DungeonEthereum/Dungeon-Ethereum-Website/issues/14

The sum of the balance for each pool was displayed instead of the sum of pending amounts for each pool.