### PR TITLE
[Improvement] Add block countdown for raids

### DIFF
--- a/src/app/raid/raid.component.html
+++ b/src/app/raid/raid.component.html
@@ -28,7 +28,9 @@
         </div>
         <div class="p-3 col-lg-6 col-md-12">
           <div class="big-block">
-            <p class="">Next raid at block {{nextRaidBlock}}</p>
+            <p *ngIf="nextRaidBlock > currentBlock">Next raid at block {{nextRaidBlock}}</p>
+            <p *ngIf="nextRaidBlock <= currentBlock">Last raid was at block {{nextRaidBlock}}</p>
+            <p *ngIf="nextRaidBlock > currentBlock">Blocks left until raid: {{nextRaidBlock - currentBlock}}</p>
             <p class="">Your {{knights | number:"1.0-2"}} knights are ready to battle!</p>
             <p class=""
                *ngIf="raidJoinedResult !== null">{{raidJoinedResult ? "You did it! You joined the Raid at the right moment!" :

--- a/src/app/raid/raid.component.html
+++ b/src/app/raid/raid.component.html
@@ -30,7 +30,7 @@
           <div class="big-block">
             <p *ngIf="nextRaidBlock > currentBlock">Next raid at block {{nextRaidBlock}}</p>
             <p *ngIf="nextRaidBlock <= currentBlock">Last raid was at block {{nextRaidBlock}}</p>
-            <p *ngIf="nextRaidBlock > currentBlock">Blocks left until raid: {{nextRaidBlock - currentBlock}}</p>
+            <p *ngIf="nextRaidBlock > currentBlock">Blocks left until raid: <a target="_blank" href="https://etherscan.io/block/countdown/{{nextRaidBlock}}">{{nextRaidBlock - currentBlock}}</a></p>
             <p class="">Your {{knights | number:"1.0-2"}} knights are ready to battle!</p>
             <p class=""
                *ngIf="raidJoinedResult !== null">{{raidJoinedResult ? "You did it! You joined the Raid at the right moment!" :

--- a/src/app/raid/raid.component.ts
+++ b/src/app/raid/raid.component.ts
@@ -13,6 +13,7 @@ export class RaidComponent implements OnInit, OnDestroy {
   private interval: NodeJS.Timeout;
   chest: {};
   nextRaidBlock: number;
+  currentBlock: number;
   knights = 0;
   knightsApproved = false;
   raidJoinedResult: boolean = null;
@@ -40,6 +41,7 @@ export class RaidComponent implements OnInit, OnDestroy {
   async updateUI() {
     this.chest = await this.ethService.getChestAmount();
     this.nextRaidBlock = await this.ethService.nextRaidBlock();
+    this.currentBlock = await this.ethService.getCurrentBlock();
     this.knights = await this.ethService.getBalance(Addresses.Knight);
     const share = await this.ethService.getRaidShare();
     this.claimableRewards = share > 0;

--- a/src/app/services/eth.service.ts
+++ b/src/app/services/eth.service.ts
@@ -487,6 +487,10 @@ export class EthService {
     return await this.dm.raidBlock().then(val => val.toNumber());
   }
 
+  async getCurrentBlock(): Promise<number> {
+    return await window.web3.eth.getBlockNumber();
+  }
+
   async joinRaid(amount: number): Promise<boolean> {
     const account = await this.getAccount();
     const balanceBefore = await this.getBalance(Addresses.OldKnight);


### PR DESCRIPTION
Issue: https://github.com/DungeonEthereum/Dungeon-Ethereum-Website/issues/9

Add the number of blocks left until raid:
![image](https://user-images.githubusercontent.com/72258256/95211575-b8aca100-0827-11eb-8d36-44601f6ff9a5.png)

You can click on the block number to open a new tab on the etherscan countdown, e.g: https://etherscan.io/block/countdown/11003515